### PR TITLE
Trim the BOM in `EndStruct()`

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -1024,6 +1024,8 @@ func (s *SuperAgent) EndStruct(v interface{}, callback ...func(response Response
 	if errs != nil {
 		return nil, body, errs
 	}
+	// Trim the BOM.
+	body = bytes.TrimPrefix(body, []byte("\xef\xbb\xbf"))
 	err := json.Unmarshal(body, &v)
 	if err != nil {
 		s.Errors = append(s.Errors, err)


### PR DESCRIPTION
This fixed `invalid character 'ï' looking for beginning of value` error.

https://stackoverflow.com/questions/31398044/got-error-invalid-character-%C3%AF-looking-for-beginning-of-value-from-json-unmar